### PR TITLE
[Fix] 월간 차트 데이터 수정 및 반려견 최근 산책 데이터 매핑 추가

### DIFF
--- a/components/board/ChartBoard/BoardItem/MonthlyChart.tsx
+++ b/components/board/ChartBoard/BoardItem/MonthlyChart.tsx
@@ -1,52 +1,47 @@
 import ChartDateNavigator from "@/components/navigator/ChartDateNavigator";
 import ChartSkeleton from "@/components/skeleton/ChartSkeleton";
-import { useQuery } from "@tanstack/react-query";
+import {
+  mapMonthlyLineItems,
+  useMonthlyStatisticsQuery,
+} from "@/util/api/activity-tracking";
 import dayjs from "dayjs";
-import React, { useRef } from "react";
+import React, { useMemo, useRef, useState } from "react";
 import { View } from "react-native";
 import { LineChart } from "react-native-gifted-charts";
 
-const MonthlyData: { label: string; value: number }[] = [
-  { label: "1월", value: 100 },
-  { label: "2월", value: 200 },
-  { label: "3월", value: 300 },
-  { label: "4월", value: 400 },
-  { label: "5월", value: 500 },
-  { label: "6월", value: 600 },
-  { label: "7월", value: 700 },
-  { label: "8월", value: 800 },
-  { label: "9월", value: 900 },
-  { label: "10월", value: 1000 },
-  { label: "11월", value: 1100 },
-  { label: "12월", value: 1200 },
-];
-
 const MonthlyChart = () => {
   const ref = useRef(null);
-  const [currentDate, setCurrentDate] = React.useState(dayjs());
-  const monthKey = currentDate.format("YYYY-MM");
-  const { data, isLoading } = useQuery({
-    queryKey: ["monthlyData", monthKey],
-    queryFn: async () => {
-      return MonthlyData;
-    },
-  });
+  const [currentDate, setCurrentDate] = useState(dayjs());
+  const year = currentDate.year();
+
+  const { data, isPending, isFetching } =
+    useMonthlyStatisticsQuery(currentDate);
+
+  const isYearDataReady = data?.period.year === String(year);
+
+  const chartData = useMemo(
+    () => (isYearDataReady && data ? mapMonthlyLineItems(data) : []),
+    [isYearDataReady, data],
+  );
+
+  const showChartSkeleton = isPending || isFetching || !isYearDataReady;
 
   return (
-    <View>
+    <View className="pb-2">
       <ChartDateNavigator
-        dateText={`${currentDate.year()}년 ${currentDate.month() + 1}월`}
+        dateText={`${year}년`}
         currentDate={currentDate}
-        onPrev={() => setCurrentDate((prev) => prev.subtract(1, "month"))}
-        onNext={() => setCurrentDate((prev) => prev.add(1, "month"))}
-        chartType="month"
+        onPrev={() => setCurrentDate((prev) => prev.subtract(1, "year"))}
+        onNext={() => setCurrentDate((prev) => prev.add(1, "year"))}
+        chartType="year"
       />
-      {isLoading || !data ? (
+      {showChartSkeleton ? (
         <ChartSkeleton />
       ) : (
         <LineChart
+          key={year}
           scrollRef={ref}
-          data={data}
+          data={chartData}
           color="#F25857"
           thickness={3}
           dataPointsColor="#F25857"
@@ -57,7 +52,11 @@ const MonthlyChart = () => {
           noOfSections={4}
           xAxisThickness={0}
           yAxisThickness={0}
-          curved
+          overflowBottom={16}
+          xAxisLabelsHeight={20}
+          initialSpacing={12}
+          endSpacing={12}
+          spacing={36}
         />
       )}
     </View>

--- a/components/board/HomeDashBoard/RunSummaryBoard.tsx
+++ b/components/board/HomeDashBoard/RunSummaryBoard.tsx
@@ -112,7 +112,7 @@ const RunSummaryBoard = ({
         >
           <View className="min-w-0 flex-1 pr-2">
             <Text className="text-xs font-black tracking-[1.5px] text-[#0D0F1B]">
-              WALK RECORD
+              RECENT WALK RECORD
             </Text>
             <Text
               className="mt-1 text-[10px] text-gray-500"
@@ -122,7 +122,11 @@ const RunSummaryBoard = ({
               NO. {recordNo}
             </Text>
           </View>
-          <Text className="text-[11px] font-bold text-gray-400">PUPPY</Text>
+          <Text
+            className={`text-[11px] font-bold ${pet.mbti ? "text-[#D97706]" : "text-gray-400"}`}
+          >
+            {pet.mbti || "PUPPY"}
+          </Text>
         </View>
 
         <View className="flex-1 justify-center px-3 py-3">

--- a/components/body/mypage/MyPageBody.tsx
+++ b/components/body/mypage/MyPageBody.tsx
@@ -5,6 +5,7 @@ import { Text } from "@/components/ui/text";
 import { useTrackingListQuery } from "@/util/api";
 import { FlashList } from "@shopify/flash-list";
 import { ActivityIndicator, RefreshControl, View } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 
 const MyPageBody = () => {
   const {
@@ -14,7 +15,8 @@ const MyPageBody = () => {
     refetch,
     isFetching,
   } = useTrackingListQuery();
-
+  const insets = useSafeAreaInsets();
+  const bottomPadding = insets.bottom + 120;
   const ListHeader = (
     <>
       <MyPageProfileCard />
@@ -58,7 +60,10 @@ const MyPageBody = () => {
         keyExtractor={(item) => item.id}
         renderItem={({ item }) => <FeedBoardItem {...item} />}
         numColumns={3}
-        contentContainerStyle={{ paddingBottom: 24, paddingHorizontal: 24 }}
+        contentContainerStyle={{
+          paddingBottom: bottomPadding,
+          paddingHorizontal: 24,
+        }}
         refreshing={isFetching && !isLoading}
         onRefresh={refetch}
         refreshControl={

--- a/components/skeleton/RunSummarySkeleton.tsx
+++ b/components/skeleton/RunSummarySkeleton.tsx
@@ -1,0 +1,117 @@
+import { RUN_SUMMARY_CARD_HEIGHT } from "@/components/board/HomeDashBoard/RunSummaryBoard";
+import { Skeleton } from "@/components/ui/skeleton";
+import React from "react";
+import { View } from "react-native";
+
+const BOX_BORDER_COLOR = "rgba(13, 15, 27, 0.14)";
+const PHOTO_WIDTH = 100;
+const PHOTO_HEIGHT = 132;
+
+const FieldSkeleton = () => (
+  <View className="min-w-0 flex-1">
+    <Skeleton
+      variant="rounded"
+      className="h-2.5 w-14 rounded-sm"
+      startColor="bg-gray-200"
+    />
+    <Skeleton
+      variant="rounded"
+      className="mt-2 h-4 w-16 rounded-sm"
+      startColor="bg-gray-200"
+    />
+  </View>
+);
+
+const RunSummarySkeleton = () => {
+  return (
+    <View
+      className="rounded-3xl p-1.5"
+      style={{
+        height: RUN_SUMMARY_CARD_HEIGHT,
+        backgroundColor: "rgba(242, 88, 87, 0.12)",
+        borderWidth: 1,
+        borderColor: BOX_BORDER_COLOR,
+      }}
+    >
+      <View
+        className="h-full flex-col overflow-hidden rounded-2xl bg-white"
+        style={{
+          borderWidth: 1,
+          borderColor: BOX_BORDER_COLOR,
+        }}
+      >
+        <View
+          className="flex-row items-center justify-between border-b px-4 pb-2.5 pt-3"
+          style={{ borderColor: BOX_BORDER_COLOR }}
+        >
+          <View className="min-w-0 flex-1 pr-2">
+            <Skeleton
+              variant="rounded"
+              className="h-3 w-28 rounded-sm"
+              startColor="bg-gray-200"
+            />
+            <Skeleton
+              variant="rounded"
+              className="mt-2 h-2.5 w-24 rounded-sm"
+              startColor="bg-gray-200"
+            />
+          </View>
+          <Skeleton
+            variant="rounded"
+            className="h-3 w-12 rounded-sm"
+            startColor="bg-gray-200"
+          />
+        </View>
+
+        <View className="flex-1 justify-center px-3 py-3">
+          <View className="flex-row items-start gap-3">
+            <Skeleton
+              variant="rounded"
+              className="shrink-0 rounded-sm"
+              startColor="bg-gray-200"
+              style={{ width: PHOTO_WIDTH, height: PHOTO_HEIGHT }}
+            />
+
+            <View className="min-w-0 flex-1 gap-3">
+              <View className="flex-row gap-3">
+                <FieldSkeleton />
+                <FieldSkeleton />
+              </View>
+              <View className="flex-row items-end gap-3">
+                <FieldSkeleton />
+                <View className="min-w-0 flex-1">
+                  <Skeleton
+                    variant="rounded"
+                    className="h-2.5 w-10 rounded-sm"
+                    startColor="bg-gray-200"
+                  />
+                  <Skeleton
+                    variant="rounded"
+                    className="mt-2 h-4 w-20 rounded-sm"
+                    startColor="bg-gray-200"
+                  />
+                </View>
+              </View>
+            </View>
+          </View>
+        </View>
+
+        <View
+          className="border-t px-4 py-2"
+          style={{
+            borderColor: BOX_BORDER_COLOR,
+            backgroundColor: "#FAFAFA",
+          }}
+        >
+          <Skeleton
+            variant="rounded"
+            className="h-2 w-48 rounded-sm"
+            startColor="bg-gray-200"
+          />
+        </View>
+      </View>
+    </View>
+  );
+};
+
+export default RunSummarySkeleton;

--- a/components/swiper/HomeSummarySwiper.tsx
+++ b/components/swiper/HomeSummarySwiper.tsx
@@ -1,9 +1,14 @@
 import RunSummaryBoard, {
   RUN_SUMMARY_CARD_HEIGHT,
 } from "@/components/board/HomeDashBoard/RunSummaryBoard";
+import RunSummarySkeleton from "@/components/skeleton/RunSummarySkeleton";
 import RedButtonSurface from "@/components/ui/RedButtonSurface";
 import { Text } from "@/components/ui/text";
-import { Pet, usePetStore } from "@/store/usePetStore";
+import { usePetStore } from "@/store/usePetStore";
+import {
+  mapPetLastTrackingsToSummaries,
+  usePetLastTrackingQuery,
+} from "@/util/api/activity-tracking";
 import { Ionicons } from "@expo/vector-icons";
 import { useRouter } from "expo-router";
 import * as React from "react";
@@ -16,31 +21,7 @@ import Carousel, {
 
 const CARD_HEIGHT = RUN_SUMMARY_CARD_HEIGHT;
 
-type WalkSummaryStats = {
-  time: string;
-  distance: string;
-  pace: string;
-};
-
-type PetWalkSummary = {
-  pet: Pet;
-  stats: WalkSummaryStats;
-};
-
-/** TODO: API 연동 후 실제 산책 기록으로 교체 */
-const FALLBACK_WALK_SUMMARIES: WalkSummaryStats[] = [
-  { time: "00:32:10", distance: "2.4 km", pace: "13'25\"" },
-  { time: "00:28:45", distance: "2.1 km", pace: "13'40\"" },
-  { time: "00:35:02", distance: "2.8 km", pace: "12'30\"" },
-];
-
-const buildPetWalkSummaries = (pets: Pet[]): PetWalkSummary[] =>
-  pets.map((pet, index) => ({
-    pet,
-    stats: FALLBACK_WALK_SUMMARIES[index % FALLBACK_WALK_SUMMARIES.length],
-  }));
-
-const EmptyWalkCard = () => {
+const EmptyWalkCard = ({ hasPets }: { hasPets: boolean }) => {
   const router = useRouter();
 
   return (
@@ -53,37 +34,55 @@ const EmptyWalkCard = () => {
           아직 산책 기록이 없어요
         </Text>
         <Text className="mt-1 text-center text-sm text-gray-500">
-          반려견을 등록하고 첫 산책을 시작해보세요
+          {hasPets
+            ? "첫 산책을 다녀오면 여기에 요약이 표시돼요"
+            : "반려견을 등록하고 첫 산책을 시작해보세요"}
         </Text>
       </View>
 
-      <RedButtonSurface
-        borderRadius={30}
-        backgroundColor="#F25857"
-        shadowPadding={8}
-        hostStyle={{ width: "100%" }}
-        style={{ width: "100%", height: 48 }}
-      >
-        <Pressable
-          onPress={() => router.push("/mypage/pets/create")}
-          className="h-full w-full items-center justify-center"
-          style={({ pressed }) => (pressed ? { opacity: 0.85 } : undefined)}
+      {!hasPets ? (
+        <RedButtonSurface
+          borderRadius={30}
+          backgroundColor="#F25857"
+          shadowPadding={8}
+          hostStyle={{ width: "100%" }}
+          style={{ width: "100%", height: 48 }}
         >
-          <Text className="text-sm font-semibold text-white">
-            반려견 등록하기
-          </Text>
-        </Pressable>
-      </RedButtonSurface>
+          <Pressable
+            onPress={() => router.push("/mypage/pets/create")}
+            className="h-full w-full items-center justify-center"
+            style={({ pressed }) => (pressed ? { opacity: 0.85 } : undefined)}
+          >
+            <Text className="text-sm font-semibold text-white">
+              반려견 등록하기
+            </Text>
+          </Pressable>
+        </RedButtonSurface>
+      ) : null}
     </View>
   );
 };
 
 const HomeSummarySwiper = () => {
   const petList = usePetStore((state) => state.petList);
+  const hasPets = (petList?.length ?? 0) > 0;
+  const { data, isPending, isError, error, refetch } =
+    usePetLastTrackingQuery(hasPets);
+
+  React.useEffect(() => {
+    if (isError) {
+      console.log("[HomeSummarySwiper] petLastTracking error", error);
+    }
+    if (data) {
+      console.log("[HomeSummarySwiper] petLastTracking data", data);
+    }
+  }, [data, error, isError]);
+
   const summaries = React.useMemo(
-    () => buildPetWalkSummaries(petList ?? []),
-    [petList],
+    () => mapPetLastTrackingsToSummaries(data?.activities ?? [], petList),
+    [data?.activities, petList],
   );
+
   const progress = useSharedValue<number>(0);
   const ref = React.useRef<ICarouselInstance>(null);
   const windowWidth = Dimensions.get("window").width;
@@ -96,6 +95,32 @@ const HomeSummarySwiper = () => {
       animated: true,
     });
   };
+
+  if (hasPets && isPending) {
+    return (
+      <View className="mb-4 px-6" style={{ height: CARD_HEIGHT }}>
+        <RunSummarySkeleton />
+      </View>
+    );
+  }
+
+  if (hasPets && isError) {
+    return (
+      <View className="mb-4 px-6">
+        <View
+          className="items-center justify-center rounded-3xl bg-white px-5 py-8 shadow-sm"
+          style={{ minHeight: CARD_HEIGHT }}
+        >
+          <Text
+            className="text-center text-sm text-gray-500"
+            onPress={() => refetch()}
+          >
+            산책 요약을 불러오지 못했어요.{"\n"}탭해서 다시 시도해 주세요.
+          </Text>
+        </View>
+      </View>
+    );
+  }
 
   return (
     <View className="mb-4 px-6">
@@ -143,7 +168,7 @@ const HomeSummarySwiper = () => {
         </>
       ) : (
         <View style={{ width: PAGE_WIDTH, height: CARD_HEIGHT }}>
-          <EmptyWalkCard />
+          <EmptyWalkCard hasPets={hasPets} />
         </View>
       )}
     </View>

--- a/util/api/activity-tracking/api.ts
+++ b/util/api/activity-tracking/api.ts
@@ -87,6 +87,35 @@ export const getMonthlyStatistics = async (
     `/activity-tracking/statistics/monthly?date=${date}`,
   );
 
+export type PetLastTrackingActivity = {
+  tracking_id: string;
+  started_at: string;
+  ended_at: string;
+  distance_m: number;
+  duration_sec: number;
+  average_pace: string;
+};
+
+export type PetLastTrackingItem = {
+  pet_id: string;
+  pet_name: string;
+  pet_profile_url: string | null;
+  latest_activity: PetLastTrackingActivity | null;
+};
+
+export type PetLastTrackingResponse = {
+  activities: PetLastTrackingItem[];
+};
+
+/** 펫별 마지막 산책 기록 조회 (startDate/endDate: YYYY-MM-DD) */
+export const getPetLastTrackings = async (
+  startDate: string,
+  endDate: string,
+): Promise<PetLastTrackingResponse> =>
+  apiGet<PetLastTrackingResponse>(
+    `/activity-tracking/statistics/pet/last-tracking?startDate=${startDate}&endDate=${endDate}`,
+  );
+
 /** 기준일이 속한 한 달의 일별 산책 기여도 조회 (date: YYYY-MM-DD) */
 export const getMonthlyContributions = async (
   date: string,

--- a/util/api/activity-tracking/api.ts
+++ b/util/api/activity-tracking/api.ts
@@ -56,6 +56,37 @@ export type DailyStatisticsResponse = {
   tracking: DailyTrackingItem[];
 };
 
+export type MonthlySummaryItem = {
+  label: string;
+  total_distance_m: number;
+  total_duration_sec: number;
+  total_count: number;
+};
+
+export type MonthlyContributionDay = {
+  label: string;
+  distance_m: number;
+  duration_sec: number;
+  tracking_count: number;
+};
+
+export type MonthlyStatisticsResponse = {
+  period: {
+    type: "monthly";
+    year: string;
+  };
+  monthly_summary: MonthlySummaryItem[];
+  contribution_chart: MonthlyContributionDay[];
+};
+
+/** 기준 연도의 월별 통계와 최근 15주 일별 기여도 조회 (date: YYYY-MM-DD) */
+export const getMonthlyStatistics = async (
+  date: string,
+): Promise<MonthlyStatisticsResponse> =>
+  apiGet<MonthlyStatisticsResponse>(
+    `/activity-tracking/statistics/monthly?date=${date}`,
+  );
+
 /** 기준일이 속한 한 달의 일별 산책 기여도 조회 (date: YYYY-MM-DD) */
 export const getMonthlyContributions = async (
   date: string,

--- a/util/api/activity-tracking/index.ts
+++ b/util/api/activity-tracking/index.ts
@@ -2,5 +2,6 @@ export * from "./api";
 export * from "./useDailyStatisticsQuery";
 export * from "./useGrassChartContributionsQuery";
 export * from "./useMonthlyStatisticsQuery";
+export * from "./usePetLastTrackingQuery";
 export * from "./useRefreshActivityTrackingOnFocus";
 export * from "./useWeeklyStatisticsQuery";

--- a/util/api/activity-tracking/index.ts
+++ b/util/api/activity-tracking/index.ts
@@ -1,5 +1,6 @@
 export * from "./api";
 export * from "./useDailyStatisticsQuery";
 export * from "./useGrassChartContributionsQuery";
+export * from "./useMonthlyStatisticsQuery";
 export * from "./useRefreshActivityTrackingOnFocus";
 export * from "./useWeeklyStatisticsQuery";

--- a/util/api/activity-tracking/useMonthlyStatisticsQuery.ts
+++ b/util/api/activity-tracking/useMonthlyStatisticsQuery.ts
@@ -1,0 +1,51 @@
+import { useQuery } from "@tanstack/react-query";
+import dayjs, { Dayjs } from "dayjs";
+import { queryKeys } from "../core/queryKeys";
+import {
+  getMonthlyStatistics,
+  type MonthlyStatisticsResponse,
+} from "./api";
+
+const MONTH_LABELS: Record<string, string> = {
+  JANUARY: "1월",
+  FEBRUARY: "2월",
+  MARCH: "3월",
+  APRIL: "4월",
+  MAY: "5월",
+  JUNE: "6월",
+  JULY: "7월",
+  AUGUST: "8월",
+  SEPTEMBER: "9월",
+  OCTOBER: "10월",
+  NOVEMBER: "11월",
+  DECEMBER: "12월",
+};
+
+export type MonthlyLineItem = {
+  label: string;
+  value: number;
+};
+
+/** API monthly_summary → 월별 거리(km) 라인 데이터 */
+export const mapMonthlyLineItems = (
+  response: MonthlyStatisticsResponse,
+): MonthlyLineItem[] =>
+  response.monthly_summary.map((item) => ({
+    label: MONTH_LABELS[item.label] ?? item.label,
+    value: Math.round((item.total_distance_m / 1000) * 100) / 100,
+  }));
+
+/** 기준 연도의 월간 통계 (referenceDate가 속한 해) */
+export const useMonthlyStatisticsQuery = (referenceDate: Dayjs) => {
+  const year = referenceDate.format("YYYY");
+  const dateKey = referenceDate.isSame(dayjs(), "year")
+    ? dayjs().format("YYYY-MM-DD")
+    : referenceDate.endOf("year").format("YYYY-MM-DD");
+
+  return useQuery({
+    queryKey: queryKeys.activityTracking.monthlyStatistics(year),
+    queryFn: () => getMonthlyStatistics(dateKey),
+    staleTime: 0,
+    refetchOnMount: "always",
+  });
+};

--- a/util/api/activity-tracking/usePetLastTrackingQuery.ts
+++ b/util/api/activity-tracking/usePetLastTrackingQuery.ts
@@ -1,0 +1,130 @@
+import type { Pet } from "@/store/usePetStore";
+import { useQuery } from "@tanstack/react-query";
+import dayjs from "dayjs";
+import { queryKeys } from "../core/queryKeys";
+import {
+  getPetLastTrackings,
+  type PetLastTrackingActivity,
+  type PetLastTrackingItem,
+} from "./api";
+
+export const PET_LAST_TRACKING_RANGE_DAYS = 89;
+
+export type WalkSummaryStats = {
+  time: string;
+  distance: string;
+  pace: string;
+};
+
+export type PetWalkSummaryCard = {
+  pet: Pet;
+  stats: WalkSummaryStats;
+  trackingId: string | null;
+};
+
+const EMPTY_WALK_STATS: WalkSummaryStats = {
+  time: "00:00:00",
+  distance: "0.0 km",
+  pace: "0'00\"",
+};
+
+const formatWalkTime = (totalSeconds: number) => {
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+  return `${hours.toString().padStart(2, "0")}:${minutes
+    .toString()
+    .padStart(2, "0")}:${seconds.toString().padStart(2, "0")}`;
+};
+
+const formatDistanceKm = (meters: number) => {
+  const km = meters / 1000;
+  const value = km >= 10 ? Math.round(km).toString() : km.toFixed(1);
+  return `${value} km`;
+};
+
+const formatPace = (pace: string) => {
+  if (!pace) return "0'00\"";
+  if (pace.endsWith('"') || pace.endsWith("''")) return pace;
+  return `${pace}"`;
+};
+
+export const mapActivityToStats = (
+  activity: PetLastTrackingActivity | null,
+): WalkSummaryStats => {
+  if (!activity) return EMPTY_WALK_STATS;
+
+  return {
+    time: formatWalkTime(activity.duration_sec),
+    distance: formatDistanceKm(activity.distance_m),
+    pace: formatPace(activity.average_pace),
+  };
+};
+
+const FALLBACK_PET_COLOR = "#F25857";
+const FALLBACK_BREED_CODE = "000";
+
+/** API 활동 + 스토어 펫 → 카드용 Pet */
+export const resolvePetForSummary = (
+  activity: PetLastTrackingItem,
+  petList: Pet[] | null | undefined,
+): Pet => {
+  const stored = petList?.find((pet) => pet.petId === activity.pet_id);
+  if (stored) {
+    return {
+      ...stored,
+      name: stored.name || activity.pet_name,
+      profileImageUrl:
+        stored.profileImageUrl ?? activity.pet_profile_url ?? null,
+    };
+  }
+
+  return {
+    petId: activity.pet_id,
+    name: activity.pet_name,
+    profileImageUrl: activity.pet_profile_url,
+    color: FALLBACK_PET_COLOR,
+    breedCode: FALLBACK_BREED_CODE,
+    badgeCode: "000",
+    birthYear: null,
+    weight: 0,
+  };
+};
+
+export const mapPetLastTrackingsToSummaries = (
+  activities: PetLastTrackingItem[],
+  petList: Pet[] | null | undefined,
+): PetWalkSummaryCard[] =>
+  activities.map((item) => ({
+    pet: resolvePetForSummary(item, petList),
+    stats: mapActivityToStats(item.latest_activity),
+    trackingId: item.latest_activity?.tracking_id ?? null,
+  }));
+
+/** 펫별 최근 산책 요약 (홈 카드) */
+export const usePetLastTrackingQuery = (enabled = true) => {
+  const endDate = dayjs().format("YYYY-MM-DD");
+  const startDate = dayjs()
+    .subtract(PET_LAST_TRACKING_RANGE_DAYS - 1, "day")
+    .format("YYYY-MM-DD");
+
+  return useQuery({
+    queryKey: queryKeys.activityTracking.petLastTracking(startDate, endDate),
+    queryFn: async () => {
+      console.log("[petLastTracking] request", { startDate, endDate });
+      try {
+        const response = await getPetLastTrackings(startDate, endDate);
+        console.log(
+          "[petLastTracking] response",
+          JSON.stringify(response, null, 2),
+        );
+        return response;
+      } catch (error) {
+        console.log("[petLastTracking] error", error);
+        throw error;
+      }
+    },
+    enabled,
+    staleTime: 1000 * 60 * 2,
+  });
+};

--- a/util/api/core/queryKeys.ts
+++ b/util/api/core/queryKeys.ts
@@ -64,6 +64,13 @@ export const queryKeys = {
       [...queryKeys.activityTracking.all, "weeklyStatistics", date] as const,
     dailyStatistics: (date: string) =>
       [...queryKeys.activityTracking.all, "dailyStatistics", date] as const,
+    petLastTracking: (startDate: string, endDate: string) =>
+      [
+        ...queryKeys.activityTracking.all,
+        "petLastTracking",
+        startDate,
+        endDate,
+      ] as const,
   },
   notifications: {
     all: ["notifications"] as const,

--- a/util/api/core/queryKeys.ts
+++ b/util/api/core/queryKeys.ts
@@ -54,6 +54,8 @@ export const queryKeys = {
     all: ["activityTracking"] as const,
     monthlyContributions: (date: string) =>
       [...queryKeys.activityTracking.all, "monthlyContributions", date] as const,
+    monthlyStatistics: (year: string) =>
+      [...queryKeys.activityTracking.all, "monthlyStatistics", year] as const,
     grassChart: (endDate: string) =>
       [...queryKeys.activityTracking.all, "grassChart", endDate] as const,
     weeklyChart: (weekStart: string) =>

--- a/util/api/tracking/useSaveTrackingMutation.ts
+++ b/util/api/tracking/useSaveTrackingMutation.ts
@@ -22,6 +22,9 @@ export const useSaveTrackingMutation = () => {
         queryKey: queryKeys.walks.recentSummaries(),
       });
       queryClient.invalidateQueries({
+        queryKey: queryKeys.activityTracking.all,
+      });
+      queryClient.invalidateQueries({
         queryKey: queryKeys.tracking.list(),
       });
     },

--- a/util/api/walks/useSaveWalkMutation.ts
+++ b/util/api/walks/useSaveWalkMutation.ts
@@ -19,6 +19,9 @@ export const useSaveWalkMutation = () => {
       queryClient.invalidateQueries({
         queryKey: queryKeys.walks.recentSummaries(),
       });
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.activityTracking.all,
+      });
     },
   });
 };


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#58 #56 

## #️⃣ 작업 내용

- 월간 차트 필터 연단위 변경 1월부터 12월까지 산책 거리 표시
- 홈 대시보드에 반려견별 최근 산책 데이터 추가
- 피드 하단 패딩 증가

## #️⃣ 테스트 결과

- 정상 렌더링 확인

